### PR TITLE
fix: display blog items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-<<<<<<< HEAD
-# SassResponsive
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 11.0.2.
+# Sass-responsive
+
+> Simple responsive Angular 11 app using sass 
+
+
 
 ## Development server
 
@@ -23,10 +25,3 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
-=======
-# Sass-responsive
-Simple responsive Angular app using sass 
->>>>>>> 3ad5c0913c11dcbcd02aa96d5f9ca760e6f35f60

--- a/src/app/my-module/components/news-page/news-page.component.html
+++ b/src/app/my-module/components/news-page/news-page.component.html
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <div class="blog-content p-2" *ngFor="let blog of blogs">
+  <div class="blog-content p-2" *ngFor="let blog of allBlogs">
     <div class="blog-img">
       <img class="blog-image shadow img-fluid" [src]="blog.bg_img" alt="Fetching image">
       <div class="blog-img-overlay">
@@ -25,6 +25,7 @@
         </div>
       </div>
     </div>
+    
 
     <div class="blog-body p-2 mb-4">
       <p class="blog-photography">{{blog.bg_category}}</p>

--- a/src/app/my-module/components/news-page/news-page.component.html
+++ b/src/app/my-module/components/news-page/news-page.component.html
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <div class="blog-content p-2" *ngFor="let blog of allBlogs">
+  <div class="blog-content p-2" *ngFor="let blog of blogs">
     <div class="blog-img">
       <img class="blog-image shadow img-fluid" [src]="blog.bg_img" alt="Fetching image">
       <div class="blog-img-overlay">

--- a/src/app/my-module/components/news-page/news-page.component.ts
+++ b/src/app/my-module/components/news-page/news-page.component.ts
@@ -3,11 +3,22 @@ import {BackendService} from '../../services/backend.service';
 import {Router} from '@angular/router';
 import {Blog} from '../../../interfaces/blogs';
 
+export interface blogItem {
+  id: number,
+  bg_img: string,
+  bg_title: string,
+  bg_content: string,
+  bg_author: string,
+  bg_upload_date: string,
+  bg_category: string
+}
+
 @Component({
   selector: 'app-news-page',
   templateUrl: './news-page.component.html',
   styleUrls: ['./news-page.component.sass']
 })
+
 export class NewsPageComponent implements OnInit {
   // blogs = {
   //   id: '',


### PR DESCRIPTION
**fix:** display blog items
**docs:** edit readme to show the project name


Notes
-------
Take note of the interface declared on the `blog item`. The reason for the failure was because we receive an array of objects from the server. However, you had declared it as an `object` in itself. 

Had you declared it as an array it might have worked. If we went:
```ts
blogs: [ ] = [ ];
```
This would have declared that blogs were an empty array of type empty array. By default, if you do not declare what type of data an array would contain, it goes to `never`. We cannot get anything from `never` . Not even `null`. We have said this array will have data, but that this data is type `never`. So the right way was to declare that it would be an array of objects, either by creating an interface or other. I went the interface way for now.